### PR TITLE
add WinRPM to REQUIRE for Windows

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.2
 BinDeps
 MathProgBase 0.3.0-dev1 0.4.0-
 @osx Homebrew
+@windows WinRPM


### PR DESCRIPTION
this is against the `cbc_c` branch

cc @mlubin
