### PR TITLE
Cbc package in WinRPM was renamed and accepted

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,11 +18,9 @@ end
 end
 @windows_only begin
     using WinRPM
-    push!(WinRPM.sources, "http://download.opensuse.org/repositories/home:/kelman:/mingw-coinor/openSUSE_13.1")
-    WinRPM.update()
     libclp = library_dependency("libclp",aliases=["libClp-1"])
     libcbcsolver = library_dependency("libcbcsolver",aliases=["libCbcSolver-3"], validate=validate)
-    provides(WinRPM.RPM, "coin-or-Cbc", [libclp,libcbcsolver], os = :Windows)
+    provides(WinRPM.RPM, "Cbc", [libclp,libcbcsolver], os = :Windows)
 end
 
 cbcname = "Cbc-2.8.12"


### PR DESCRIPTION
in official opensuse mingw project - see
https://build.opensuse.org/package/show/windows:mingw:win32/mingw32-Cbc
and https://build.opensuse.org/package/show/windows:mingw:win64/mingw64-Cbc
