### PR TITLE
Use latest version 2.9.1

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -32,7 +32,7 @@ end
     provides(WinRPM.RPM, "Cbc", [libclp,libcbcsolver], os = :Windows)
 end
 
-cbcname = "Cbc-2.8.12"
+cbcname = "Cbc-2.9.1"
 
 provides(Sources, URI("http://www.coin-or.org/download/source/Cbc/$cbcname.tgz"),
     [libclp,libcbcsolver], os = :Unix)
@@ -54,7 +54,7 @@ provides(SimpleBuild,
         GetSources(libclp)
         @build_steps begin
             ChangeDirectory(srcdir)
-            `./configure --prefix=$prefix --enable-dependency-linking --without-blas --without-lapack --enable-cbc-parallel`
+            `./configure --prefix=$prefix --without-blas --without-lapack --enable-cbc-parallel`
             `make install`
         end
     end),[libclp,libcbcsolver], os = :Unix)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,3 @@
+JuMP
+FactCheck
+Clp

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,7 @@ using Cbc
 include(joinpath(Pkg.dir("MathProgBase"),"test","mixintprog.jl"))
 
 mixintprogtest(CbcSolver(logLevel=1))
+
+if isdir(Pkg.dir("JuMP"))
+    include(joinpath(Pkg.dir("JuMP"),"test","runtests.jl"))
+end


### PR DESCRIPTION
--enable-dependency-linking is supposedly default now, but removing
it did not work, libClp was not linked correctly to libCoinUtils

I was not expecting this at all, but the latest version of OS (2.9.0) fails a Clp-related unit test if you try to use it with the few-months-old version of Cbc (2.8.12) that we've been using here.