### PR TITLE
bump source to 2.9.8

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -33,7 +33,7 @@ if is_windows()
     provides(WinRPM.RPM, "Cbc", [libclp,libcbcsolver], os = :Windows)
 end
 
-cbcname = "Cbc-2.9.1"
+cbcname = "Cbc-2.9.8"
 
 provides(Sources, URI("http://www.coin-or.org/download/source/Cbc/$cbcname.tgz"),
     [libclp,libcbcsolver], os = :Unix)


### PR DESCRIPTION
Homebrew is already running on 2.9.7 which should be good enough.
@tkelman, looks like opensuse is on 2.9.2, would it be hard to bump?