### PR TITLE
don't run JuMP's tests

### DIFF
--- a/src/CbcSolverInterface.jl
+++ b/src/CbcSolverInterface.jl
@@ -33,7 +33,7 @@ mutable struct CbcMathProgModel <: AbstractLinearQuadraticModel
 end
 
 mutable struct CbcSolver <: AbstractMathProgSolver
-    options 
+    options
 end
 CbcSolver(;kwargs...) = CbcSolver(kwargs)
 
@@ -57,10 +57,18 @@ function setparameters!(s::CbcSolver; mpboptions...)
     silent = false
     for (optname, optval) in mpboptions
         if optname == :TimeLimit
-            push!(opts, (:seconds,optval))
+            @static if VERSION >= v"0.7-"
+                push!(opts, :seconds => optval)
+            else
+                push!(opts, (:seconds, optval))
+            end
         elseif optname == :Silent
             if optval == true
-                push!(opts, (:logLevel,0))
+                @static if VERSION >= v"0.7-"
+                    push!(opts, :logLevel => 0)
+                else
+                    push!(opts, (:logLevel, 0))
+                end
             end
         else
             error("Unrecognized parameter $optname")

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,1 @@
-JuMP
-Clp
 OffsetArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,4 @@ MathProgBase.setparameters!(solver, Silent=true, TimeLimit=100.0)
 println("Cbc should not display any output from these tests")
 coniclineartest(solver)
 
-if isdir(Pkg.dir("JuMP"))
-    include(joinpath(Pkg.dir("JuMP"),"test","runtests.jl"))
-end
-
 include("MOIWrapper.jl")


### PR DESCRIPTION
This was a bad idea and blocks tests from passing on 0.7 (https://github.com/JuliaOpt/Cbc.jl/pull/60).

Also fixes option handling which as the other blocker to get tests passing. CC @GunnarFarneback