### PR TITLE
No more importall

### DIFF
--- a/src/CbcSolverInterface.jl
+++ b/src/CbcSolverInterface.jl
@@ -1,6 +1,7 @@
 module CbcMathProgSolverInterface
 
 using Cbc.CbcCInterface
+using Compat.SparseArrays
 
 import MathProgBase
 const MPB = MathProgBase.SolverInterface

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -1,6 +1,7 @@
 export CbcOptimizer
 
 
+using Compat.SparseArrays
 using MathOptInterface
 using Cbc.CbcCInterface
 


### PR DESCRIPTION
Replace the deprecated `importall` with specific imports and module prefixed extensions.
Second commit deals with warnings from moving sparse functionality to `stdlib` in Julia 0.7.
