### PR TITLE
 Add using Compat in tests

### DIFF
--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -1,4 +1,5 @@
-using Compat.Test, MathOptInterface, MathOptInterface.Test, MathOptInterface.Utilities
+using Compat, Compat.Test
+using MathOptInterface, MathOptInterface.Test, MathOptInterface.Utilities
 
 const MOI  = MathOptInterface
 const MOIT = MathOptInterface.Test

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -75,7 +75,7 @@ end
         "solve_constant_obj",  ## cannot get with strings
         "solve_affine_deletion_edge_cases", ## do not support vector of constraints
         ## TODO: fix new tests of objective edge cases
-        "solve_duplicate_terms_obj", 
+        "solve_duplicate_terms_obj",
         "solve_objbound_edge_cases"
     ])
 end


### PR DESCRIPTION
Otherwise, the tests fails at `https://github.com/JuliaOpt/MathOptInterface.jl/blob/00b5965ea1491a893af01c0bf8b5501a0f11c4bb/src/Utilities/model.jl#L550` with MOI v0.6.2 because `Nothing` is not defined on Julia v0.6.
See https://juliarun-ci.s3.amazonaws.com/a8e4d0c3b1d78372dcdb95f9a6b6c484bf33a851/Cbc_with_pull_request_of_MathOptInterface_on_julia_0_6.log
Similar to https://github.com/JuliaOpt/SCS.jl/pull/119