### PR TITLE
Update Base.warn_once to @Compat.warn

### DIFF
--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -1,7 +1,7 @@
 module CbcMathProgSolverInterface
 
 using Cbc.CbcCInterface
-using Compat.SparseArrays
+using Compat
 
 import MathProgBase
 const MPB = MathProgBase
@@ -194,7 +194,7 @@ MPB.getrawsolver(m::CbcMathProgModel) = m.inner
 
 function MPB.setwarmstart!(m::CbcMathProgModel, v)
     if any(isnan, v)
-        Base.warn_once("Ignoring partial starting solution. Cbc requires a feasible value to be specified for all variables.")
+        @Compat.warn("Ignoring partial starting solution. Cbc requires a feasible value to be specified for all variables.")
         return
     end
 


### PR DESCRIPTION
`Base.warn_once` was deprecated in favor of `@Compat.warn` in Julia 0.7, and removed in 1.0. 

As a result, with Julia 1.0+ I get `UndefVarError: warn_once not defined` if I don't have Compat loaded. 