### PR TITLE
Allow 64-bit int input in 32-bit system

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -22,7 +22,7 @@ struct CbcModelFormat
     obj::Vector{Float64}
     row_lb::Vector{Float64}
     row_ub::Vector{Float64}
-    function CbcModelFormat(num_rows::Int, num_cols::Int)
+    function CbcModelFormat(num_rows::Integer, num_cols::Integer)
         obj = fill(0.0, num_cols)
         row_idx = Int[]
         col_idx = Int[]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -22,9 +22,6 @@ struct CbcModelFormat
     obj::Vector{Float64}
     row_lb::Vector{Float64}
     row_ub::Vector{Float64}
-    # `num_cols` is `Int64` if the model is copied from a model create with
-    # `MOIU.@model`, it is converted to `Int32` in `new` and throws an
-    # `InexactError` in case it is too large.
     function CbcModelFormat(num_rows::Integer, num_cols::Integer)
         obj = fill(0.0, num_cols)
         row_idx = Int[]
@@ -35,6 +32,9 @@ struct CbcModelFormat
         row_lb = fill(-Inf, num_rows)
         row_ub = fill(Inf, num_rows)
         constraint_matrix = Tuple{Int,Int,Float64}[]
+        # An `InexactError` might occur if `num_rows` or `num_cols` is too
+        # large, e.g., if `num_cols isa Int64` and is larger than 2^31 on a
+        # 32-bit hardware
         new(num_rows, num_cols, row_idx, col_idx, values, col_lb, col_ub,
             obj, row_lb, row_ub)
     end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -22,6 +22,9 @@ struct CbcModelFormat
     obj::Vector{Float64}
     row_lb::Vector{Float64}
     row_ub::Vector{Float64}
+    # `num_cols` is `Int64` if the model is copied from a model create with
+    # `MOIU.@model`, it is converted to `Int32` in `new` and throws an
+    # `InexactError` in case it is too large.
     function CbcModelFormat(num_rows::Integer, num_cols::Integer)
         obj = fill(0.0, num_cols)
         row_idx = Int[]


### PR DESCRIPTION
If an `Int64` is provided that is too large to fit in an `Int32`, there will be an explicit error
```julia
julia> convert(Int32, 1 << 60)
ERROR: InexactError: trunc(Int32, 1152921504606846976)
Stacktrace:
 [1] top-level scope at none:0
```

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/612