### PR TITLE
Cache variable primal after solve

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,4 +1,4 @@
 CoinMP-1.6.0*
 usr
 deps.jl
-
+*.log

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-using Cbc
+using Cbc, Compat.Test
 
-include("MPB_wrapper.jl")
-include("MOI_wrapper.jl")
+@testset "MPB" begin
+    include("MPB_wrapper.jl")
+end
+
+@testset "MOI" begin
+    include("MOI_wrapper.jl")
+end


### PR DESCRIPTION
Running the same benchmark in #102, and we're back in good territory.

```
BenchmarkTools.Trial:
  memory estimate:  6.63 MiB
  allocs estimate:  389495
  --------------
  minimum time:     31.000 ms (0.00% GC)
  median time:      33.916 ms (0.00% GC)
  mean time:        35.814 ms (2.82% GC)
  maximum time:     71.201 ms (0.00% GC)
  --------------
  samples:          140
  evals/sample:     1
```

Closes #102 

cc @ndinsmore