### PR TITLE
Add Compat to test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,8 @@ MathProgBase = "~0.5.5, ~0.6, ~0.7"
 julia = "1"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Compat", "Test"]


### PR DESCRIPTION
While not used directly in the source code, the tests are including a file from another package which does require Compat.