### PR TITLE
Use setMIPStartI function for warmstart.

### DIFF
--- a/src/CbcCInterface.jl
+++ b/src/CbcCInterface.jl
@@ -9,6 +9,7 @@ export CbcModel,
     readMps,
     writeMps,
     setInitialSolution,
+    setMIPStartI,
     problemName,
     setProblemName,
     getNumElements,
@@ -166,6 +167,11 @@ end
 function setInitialSolution(prob::CbcModel, array::Vector{Float64})
     check_problem(prob)
     @cbc_ccall setInitialSolution Cvoid (Ptr{Cvoid}, Ptr{Float64}) prob array
+end
+
+function setMIPStartI(prob::CbcModel, columns::Vector{Cint}, array::Vector{Float64})
+    check_problem(prob)
+    @cbc_ccall setMIPStartI Cvoid (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Float64}) prob length(columns) columns array
 end
 
 function problemName(prob::CbcModel)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -543,9 +543,7 @@ function MOI.optimize!(model::Optimizer)
             push!(columns, variable.value - 1)
             push!(values, value)
         end
-        # FIXME in https://github.com/JuliaOpt/Cbc.jl/pull/128/
-        # CbcCI.setMIPStartI(model.inner, columns, values)
-        error("Starting values for variable primal coming to the next release!")
+        CbcCI.setMIPStartI(model.inner, columns, values)
     end
     CbcCI.solve(model.inner)
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -69,16 +69,12 @@ end
 end
 
 @testset "Continuous Linear" begin
-    MOIT.contlineartest(BRIDGED, CONFIG,
-                        # FIXME starting values
-                        ["partial_start"])
+    MOIT.contlineartest(BRIDGED, CONFIG)
 end
 
 @testset "Integer Linear" begin
     MOIT.intlineartest(BRIDGED, CONFIG, [
-        "indicator1", "indicator2", "indicator3", "indicator4",
-        # FIXME starting values
-        "knapsack"
+        "indicator1", "indicator2", "indicator3", "indicator4"
     ])
 end
 


### PR DESCRIPTION
This PR adds the recently added Cbc function `setMIPStartI` to `CbcCInterface` and uses it in the MPB `setwarmstart!` function instead of `setInitialSolution`.

As a result the Cbc warmstart becomes silent, which solves #78 and possibly also #41, although that issue is very vague on details.
