### PR TITLE
Pass attributes instead of ignoring them

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -69,12 +69,16 @@ end
 end
 
 @testset "Continuous Linear" begin
-    MOIT.contlineartest(BRIDGED, CONFIG)
+    MOIT.contlineartest(BRIDGED, CONFIG,
+                        # FIXME starting values
+                        ["partial_start"])
 end
 
 @testset "Integer Linear" begin
     MOIT.intlineartest(BRIDGED, CONFIG, [
-        "indicator1", "indicator2", "indicator3", "indicator4"
+        "indicator1", "indicator2", "indicator3", "indicator4",
+        # FIXME starting values
+        "knapsack"
     ])
 end
 


### PR DESCRIPTION
Currently, `MOI.copy_to` ignores attribute that it does not know instead of throwing an `UnsupportedAttribute` error.
This PR pass the attributes and adds the skeleton for supporting starting values in https://github.com/JuliaOpt/Cbc.jl/pull/128/