### PR TITLE
Add function barrier for type instability in constraint copy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
+  - 1.3
+  - 1.4
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ julia = "1"
 
 [extras]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Compat", "Test"]
+test = ["Compat", "LinearAlgebra", "Test"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.1
+  - julia_version: 1.3
 
 platform:
   - x86 # 32-bit


### PR DESCRIPTION
Should improve the timing of https://medium.com/@vanstark88/construction-speed-in-popular-open-source-math-modeling-tools-712fd841fc50

The following code:
```julia
N = 100000
model = MOIU.Model{Float64}()
x = MOI.add_variables(model, N)
MOI.add_constraints(model, MOI.SingleVariable.(x), [MOI.Integer() for i in 1:N])
optimizer = Cbc.Optimizer()
@time MOI.copy_to(optimizer, model);
```
gives
```
0.267909 seconds (1.40 M allocations: 47.611 MiB)
```
with master and gives
```
0.148257 seconds (201.01 k allocations: 29.324 MiB, 16.74% gc time)
```
with this PR
Note that the number of allocation was divided by 7.